### PR TITLE
Make game statistics chart chronological

### DIFF
--- a/src/main/java/dk/frankbille/scoreboard/components/GameStatisticsPanel.java
+++ b/src/main/java/dk/frankbille/scoreboard/components/GameStatisticsPanel.java
@@ -63,7 +63,8 @@ public class GameStatisticsPanel extends Panel {
         Collections.sort(games, new Comparator<Game>() {
             @Override
             public int compare(Game o1, Game o2) {
-                return o1.getId().compareTo(o2.getId());
+                final int dateComparison = o1.getDate().compareTo(o2.getDate());
+                return dateComparison == 0 ? o1.getId().compareTo(o2.getId()) : dateComparison;
             }
         });
 


### PR DESCRIPTION
Added a date comparison when plotting the game statistics chart. This means that the chart shows data chronologically even if the games are not entered chronologically.
